### PR TITLE
fix: use `recheck` instead of `@makenowjust-labo/recheck`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 const fs = require("fs/promises")
 const glob = require("glob")
 const meow = require("meow")
-const { check } = require("@makenowjust-labo/recheck")
+const { checkSync } = require("recheck")
 
 const cli = meow(
   `
@@ -84,7 +84,7 @@ const parseRegexes = async (file) => {
   return fileLines.reduce((obj, line, index) => {
     if (re.test(line)) {
       const foundRegex = line.match(re)
-      const checkResult = check(foundRegex[0].slice(1, -1), "", {
+      const checkResult = checkSync(foundRegex[0].slice(1, -1), "", {
         timeout: 1000,
         checker: "hybrid",
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,20 @@
 {
   "name": "recheck-cli",
-  "version": "0.0.4",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.4",
+      "name": "recheck-cli",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@makenowjust-labo/recheck": "^3.0.0",
         "glob": "^7.1.6",
-        "meow": "^9.0.0"
+        "meow": "^9.0.0",
+        "recheck": "^4.1.1"
+      },
+      "bin": {
+        "recheck-cli": "cli.js"
       },
       "devDependencies": {
         "eslint": "^7.25.0",
@@ -109,11 +113,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@makenowjust-labo/recheck": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@makenowjust-labo/recheck/-/recheck-3.0.0.tgz",
-      "integrity": "sha512-B+GNE/QnbCrUuXaAiU+tm3qjg9x5/rQ54YVSjFvgUZ/Wv++oUMZQHSpM3ANTmKjiBRuPGfkYYDoqahWpK5eR6w=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -2559,6 +2558,52 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/recheck": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/recheck/-/recheck-4.1.1.tgz",
+      "integrity": "sha512-4+OOzl277ZtosPgA33bz9Dq1SXXY7vT5ddUBn7fMPGa76yz5R989X5u4x9jGjnJLfdaQm1YhWZyQRsnq0BN4ng==",
+      "optionalDependencies": {
+        "recheck-linux-x64": "4.1.1",
+        "recheck-macos-x64": "4.1.1",
+        "recheck-windows-x64": "4.1.1"
+      }
+    },
+    "node_modules/recheck-linux-x64": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/recheck-linux-x64/-/recheck-linux-x64-4.1.1.tgz",
+      "integrity": "sha512-Bt0RrAuhUYuuT4eiubut0xsOv3pXw2FYMpgx4rDJ+YkoC6mNdQSvZQW452UOo4UTCLZBYIaW0SWp2iuqdsITRg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/recheck-macos-x64": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/recheck-macos-x64/-/recheck-macos-x64-4.1.1.tgz",
+      "integrity": "sha512-SPAx/LuNblunEJMkLq7KgHCPJGFWTir77cLuE+c/q/ed2Yph5Rw/k+H+c7DolbtJZYAyPHv2nIWyqVUGRwuJAg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/recheck-windows-x64": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/recheck-windows-x64/-/recheck-windows-x64-4.1.1.tgz",
+      "integrity": "sha512-eA93cP8xB2J1bKjViIJhx7nKL2OUPL/9FAbq3fp4MMm33pYFv+nU67Q20HrrgKSa1jPnxdb7Hk0n0rtRtpysqA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3384,11 +3429,6 @@
           "dev": true
         }
       }
-    },
-    "@makenowjust-labo/recheck": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@makenowjust-labo/recheck/-/recheck-3.0.0.tgz",
-      "integrity": "sha512-B+GNE/QnbCrUuXaAiU+tm3qjg9x5/rQ54YVSjFvgUZ/Wv++oUMZQHSpM3ANTmKjiBRuPGfkYYDoqahWpK5eR6w=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -5221,6 +5261,34 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "recheck": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/recheck/-/recheck-4.1.1.tgz",
+      "integrity": "sha512-4+OOzl277ZtosPgA33bz9Dq1SXXY7vT5ddUBn7fMPGa76yz5R989X5u4x9jGjnJLfdaQm1YhWZyQRsnq0BN4ng==",
+      "requires": {
+        "recheck-linux-x64": "4.1.1",
+        "recheck-macos-x64": "4.1.1",
+        "recheck-windows-x64": "4.1.1"
+      }
+    },
+    "recheck-linux-x64": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/recheck-linux-x64/-/recheck-linux-x64-4.1.1.tgz",
+      "integrity": "sha512-Bt0RrAuhUYuuT4eiubut0xsOv3pXw2FYMpgx4rDJ+YkoC6mNdQSvZQW452UOo4UTCLZBYIaW0SWp2iuqdsITRg==",
+      "optional": true
+    },
+    "recheck-macos-x64": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/recheck-macos-x64/-/recheck-macos-x64-4.1.1.tgz",
+      "integrity": "sha512-SPAx/LuNblunEJMkLq7KgHCPJGFWTir77cLuE+c/q/ed2Yph5Rw/k+H+c7DolbtJZYAyPHv2nIWyqVUGRwuJAg==",
+      "optional": true
+    },
+    "recheck-windows-x64": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/recheck-windows-x64/-/recheck-windows-x64-4.1.1.tgz",
+      "integrity": "sha512-eA93cP8xB2J1bKjViIJhx7nKL2OUPL/9FAbq3fp4MMm33pYFv+nU67Q20HrrgKSa1jPnxdb7Hk0n0rtRtpysqA==",
+      "optional": true
     },
     "redent": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Nico Domino <yo@ndo.dev>",
   "license": "MIT",
   "dependencies": {
-    "@makenowjust-labo/recheck": "^3.0.0",
+    "recheck": "^4.1.1",
     "glob": "^7.1.6",
     "meow": "^9.0.0"
   },


### PR DESCRIPTION
Thanks for using `recheck`. I'm `recheck` author, and I'm going to announce a new version of `recheck`.

Since v4.0.0, we renamed `@makenowjust-labo/recheck` to `recheck`, and `check` is now `checkSync`.
This PR fixes by following these changes.

Ref MakeNowJust-Labo/recheck#144